### PR TITLE
Add VSCode Task Parser

### DIFF
--- a/Scripts/VSCodeTaskAssistant.js
+++ b/Scripts/VSCodeTaskAssistant.js
@@ -1,0 +1,45 @@
+module.exports.ComposerTaskAssistant = class VSCodeTaskAssistant {
+  constructor() {
+	this.packageProcessName = "code";
+	this.packageJsonPath = nova.workspace.path + "/.vscode/tasks.json";
+  }
+
+  provideTasks() {
+	let tasks = [];
+	
+	let composerFile = nova.fs.stat(this.packageJsonPath);
+
+	/*
+	 * composer.json
+	 */
+	if (composerFile && composerFile.isFile()) {
+	  try {
+		let pack = JSON.parse(nova.fs.open(this.packageJsonPath).read());
+		console.log(pack);
+// 		if (pack.hasOwnProperty("tasks")) {
+// 		  for (var vsTask in pack.tasks) {
+// 			if (pack.scripts.hasOwnProperty(vsTask)) {
+// 			  // Add Task
+// 			  let task = new Task(vsTask);
+// 
+// 			  task.setAction(
+// 				Task.Run,
+// 				new TaskProcessAction(this.packageProcessName, {
+// 				  args: [],
+// 				  shell: true,
+// 				  cwd: nova.workspace.path,
+// 				})
+// 			  );
+// 			  tasks.push(task);
+// 			  task = null;
+// 			}
+// 		  }
+// 		}
+	  } catch (e) {
+		console.log(e);
+	  }
+	}
+
+	return tasks;
+  }
+};

--- a/Scripts/VSCodeTaskAssistant.js
+++ b/Scripts/VSCodeTaskAssistant.js
@@ -23,20 +23,19 @@ module.exports.VSCodeTaskAssistant = class VSCodeTaskAssistant {
 			
 			let task = new Task(vsTask.label)
 			
-			let words = vsTask.command.split(' ');
-			let command = words.shift();
-			let args = words.join(' ');
-			let action = new TaskProcessAction(command, {
-				args: [args],
-				shell: true,
-				cwd: nova.workspace.path
-			});
+			let args = vsTask.command.split(' ');
+			let command = args.shift();
 			
-			if (vsTask.group == "build" || vsTask.group.kind == "build") {
-				task.setAction(Task.Build, action)				
-			} else {
-				task.setAction(Task.Run, action)
-			}
+			let cwd = nova.workspace.path
+			
+			task.setAction(
+				vsTask.group == "build" || vsTask.group.kind == "build" ? Task.Build : Task.Run, 
+				new TaskProcessAction(command, {
+					args: args,
+					shell: true,
+					cwd: cwd
+				})
+			);
 		
 			tasks.push(task)
 		})

--- a/Scripts/VSCodeTaskAssistant.js
+++ b/Scripts/VSCodeTaskAssistant.js
@@ -1,55 +1,65 @@
 module.exports.VSCodeTaskAssistant = class VSCodeTaskAssistant {
   constructor() {
-	this.packageProcessName = "code";
-	this.packageJsonPath = nova.workspace.path + "/.vscode/tasks.json";
+    this.packageProcessName = "code";
+    this.packageJsonPath = nova.workspace.path + "/.vscode/tasks.json";
   }
 
   provideTasks() {
-	let tasks = [];
-	let tasksFile = nova.fs.stat(this.packageJsonPath);
+    let tasks = [];
+    let tasksFile = nova.fs.stat(this.packageJsonPath);
 
-	/*
-	 * tasks.json
-	 */
-	if (tasksFile && tasksFile.isFile()) {
-	  try {
-		const commentRegex = /^( *\/\/.*\n)/gm;
-		const trailingCommaRegex = /\,(?!\s*?[\{\[\"\'\w])/gm;
-		let fileContents = nova.fs.open(this.packageJsonPath).read().replace(commentRegex, "").replace(trailingCommaRegex, "");
-		let pack = JSON.parse(fileContents);
-		
-		pack.tasks.forEach((vsTask) => {
-			if (vsTask.command === undefined) { return }
-			
-			let task = new Task(vsTask.label)
-			
-			let args = vsTask.command.split(' ');
-			let command = args.shift();
-			
-			let cwd = nova.workspace.path
-			// Creating error: ReferenceError: Can't find variable: options
-			// if (typeof vsTask.options != 'undefined' && typeof vsTask.options.cwd != 'undefined') {
-			// 	cwd = options.cwd.replace("workspaceFolder", "WorkspaceFolder").replace("fileDirname", "FileDirname")
-			// }
-			
-			task.setAction(
-				// Creating error TypeError: undefined is not an object (evaluating 'vsTask.group.kind')
-				vsTask.group == "build" || (typeof vsTask.group.kind != 'undefined' && vsTask.group.kind == "build") ? Task.Build : Task.Run, 
-				new TaskProcessAction(command, {
-					args: args,
-					shell: true,
-					cwd: cwd
-				})
-			);
-		
-			tasks.push(task)
-		})
-	  } catch (e) {
-		console.info("error");
-		console.log(e);
-	  }
-	}
+    /*
+     * tasks.json
+     */
+    if (tasksFile && tasksFile.isFile()) {
+      try {
+        const commentRegex = /^( *\/\/.*\n)/gm;
+        const trailingCommaRegex = /\,(?!\s*?[\{\[\"\'\w])/gm;
+        let fileContents = nova.fs
+          .open(this.packageJsonPath)
+          .read()
+          .replace(commentRegex, "")
+          .replace(trailingCommaRegex, "");
+        let pack = JSON.parse(fileContents);
 
-	return tasks;
+        pack.tasks.forEach((vsTask) => {
+          if (vsTask.command === undefined) {
+            return;
+          }
+
+          let task = new Task(vsTask.label);
+
+          let args = vsTask.command.split(" ");
+          let command = args.shift();
+
+          let cwd = nova.workspace.path;
+          // Creating error: ReferenceError: Can't find variable: options
+          if (typeof vsTask.options?.cwd != "undefined") {
+            cwd = vsTask.options.cwd
+              .replace("workspaceFolder", "WorkspaceFolder")
+              .replace("fileDirname", "FileDirname");
+          }
+
+          task.setAction(
+            // Creating error TypeError: undefined is not an object (evaluating 'vsTask.group.kind')
+            vsTask?.group == "build" || vsTask?.group?.kind == "build"
+              ? Task.Build
+              : Task.Run,
+            new TaskProcessAction(command, {
+              args: args,
+              shell: true,
+              cwd: cwd,
+            })
+          );
+
+          tasks.push(task);
+        });
+      } catch (e) {
+        console.info("error");
+        console.log(e);
+      }
+    }
+
+    return tasks;
   }
 };

--- a/Scripts/VSCodeTaskAssistant.js
+++ b/Scripts/VSCodeTaskAssistant.js
@@ -27,9 +27,14 @@ module.exports.VSCodeTaskAssistant = class VSCodeTaskAssistant {
 			let command = args.shift();
 			
 			let cwd = nova.workspace.path
+			// Creating error: ReferenceError: Can't find variable: options
+			// if (typeof vsTask.options != 'undefined' && typeof vsTask.options.cwd != 'undefined') {
+			// 	cwd = options.cwd.replace("workspaceFolder", "WorkspaceFolder").replace("fileDirname", "FileDirname")
+			// }
 			
 			task.setAction(
-				vsTask.group == "build" || vsTask.group.kind == "build" ? Task.Build : Task.Run, 
+				// Creating error TypeError: undefined is not an object (evaluating 'vsTask.group.kind')
+				vsTask.group == "build" || (typeof vsTask.group.kind != 'undefined' && vsTask.group.kind == "build") ? Task.Build : Task.Run, 
 				new TaskProcessAction(command, {
 					args: args,
 					shell: true,

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -1,7 +1,7 @@
 const { NodeTaskAssistant } = require("./NodeTaskAssistant.js");
 const { ComposerTaskAssistant } = require("./ComposerTaskAssistant.js");
 const { TaskfileTaskAssistant } = require("./TaskfileTaskAssistant.js");
-const { VSCodeTaskAssistant } = require("./TaskfileTaskAssistant.js");
+const { VSCodeTaskAssistant } = require("./VSCodeTaskAssistant.js");
 
 exports.activate = function () {
   // Do work when the extension is activated
@@ -62,7 +62,7 @@ exports.activate = function () {
   // VSCode Tasks
   if(nova.workspace.config.get("taskfinder.auto-vscode", "boolean")) {
     console.info("Initialising VSCodeTaskAssistant");
-    taskfileTaskDisposable = nova.assistants.registerTaskAssistant(
+    vsCodeTaskDisposable = nova.assistants.registerTaskAssistant(
       new VSCodeTaskAssistant(),
       {
         name: "VSCode",
@@ -73,7 +73,7 @@ exports.activate = function () {
       nova.workspace.reloadTasks();
     });
     nova.subscriptions.add(vsCodeFileWatcher);
-    nova.subscriptions.add(taskfileTaskDisposable);
+    nova.subscriptions.add(vsCodeTaskDisposable);
   }
 };
 

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -1,6 +1,7 @@
 const { NodeTaskAssistant } = require("./NodeTaskAssistant.js");
 const { ComposerTaskAssistant } = require("./ComposerTaskAssistant.js");
 const { TaskfileTaskAssistant } = require("./TaskfileTaskAssistant.js");
+const { VSCodeTaskAssistant } = require("./TaskfileTaskAssistant.js");
 
 exports.activate = function () {
   // Do work when the extension is activated
@@ -55,6 +56,23 @@ exports.activate = function () {
       nova.workspace.reloadTasks();
     });
     nova.subscriptions.add(taskfileFileWatcher);
+    nova.subscriptions.add(taskfileTaskDisposable);
+  }
+  
+  // VSCode Tasks
+  if(nova.workspace.config.get("taskfinder.auto-vscode", "boolean")) {
+    console.info("Initialising VSCodeTaskAssistant");
+    taskfileTaskDisposable = nova.assistants.registerTaskAssistant(
+      new VSCodeTaskAssistant(),
+      {
+        name: "VSCode",
+        identifier: "vscode-tasks",
+      }
+    );
+    let vsCodeFileWatcher = nova.fs.watch("*tasks.json*", (e) => {
+      nova.workspace.reloadTasks();
+    });
+    nova.subscriptions.add(vsCodeFileWatcher);
     nova.subscriptions.add(taskfileTaskDisposable);
   }
 };

--- a/extension.json
+++ b/extension.json
@@ -3,8 +3,8 @@
   "name": "Automatic Tasks",
   "imageName": "icon",
   "organization": "Little Green Man Ltd",
-  "description": "Automatically offers Composer, Node & Taskfile actions as Nova Tasks.",
-  "version": "3.1.3",
+  "description": "Automatically offers Composer, Node, Taskfile, & VSCode actions as Nova Tasks.",
+  "version": "3.2.0",
   "categories": ["tasks"],
 
   "homepage": "https://github.com/little-green-man/nova-taskfinder",
@@ -19,7 +19,8 @@
   "activationEvents": [
     "onWorkspaceContains:*package.json",
     "onWorkspaceContains:*composer.json",
-    "onWorkspaceContains:*Taskfile.*"
+    "onWorkspaceContains:*Taskfile.*",
+    "onWorkspaceContains:.vscode/*tasks*.json"
   ],
 
   "entitlements": {
@@ -62,6 +63,13 @@
         {
           "key": "taskfinder.auto-taskfile",
           "title": "Include Taskfile Tasks",
+          "description": "Requires workspace restart",
+          "type": "boolean",
+          "default": true
+        },
+        {
+          "key": "taskfinder.auto-vscode",
+          "title": "Include VSCode Tasks",
           "description": "Requires workspace restart",
           "type": "boolean",
           "default": true

--- a/extension.json
+++ b/extension.json
@@ -51,21 +51,21 @@
           "title": "Include Composer Tasks",
           "description": "Requires workspace restart",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         {
           "key": "taskfinder.auto-node",
           "title": "Include Node Tasks",
           "description": "Requires workspace restart",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         {
           "key": "taskfinder.auto-taskfile",
           "title": "Include Taskfile Tasks",
           "description": "Requires workspace restart",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         {
           "key": "taskfinder.auto-vscode",


### PR DESCRIPTION
Closes #10

This PR adds support for VSCode tasks. It's in the state where it can read the json file and import tasks that have shell commands attached. I'm getting some errors in the extension console (which are commented in the `VSCodeTaskAssistant` file).

Creating as a draft initially to get the discussion started.